### PR TITLE
Switch to Header Lists

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: matheus23/md-spellcheck-action@v4.1.0
+      - uses: matheus23/md-spellcheck-action@v4.2.2
         with:
           files-to-check: "**/*.md"
           files-to-exclude: |

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -1,4 +1,6 @@
 CIDs
+Bluesky
+Deduplicate
 Hardt
 Holmgren
 JSON
@@ -22,9 +24,3 @@ signalling
 trustless
 v0
 validator
-
-# wut
-HeaderTypeDescriptionRequiredCardinalityEntrypoint
-UCANNoZero
-UCANYesOneMapping
-HeaderTypeDescriptionRequiredCardinalityEntry

--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -1,5 +1,5 @@
-CIDs
 Bluesky
+CIDs
 Deduplicate
 Hardt
 Holmgren

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ The body of the response MUST include a JSON object with a `prf` field. The valu
 
 Many thanks to the authors of [RFC 6750](https://www.rfc-editor.org/rfc/rfc6750.html) — Michael B. Jones and Dick Hardt — for their work in defining the bearer authorization method.
 
-Thank you to [Chris Joel](https://github.com/cdata) of [Subconcious](https://subconscious.substack.com/), and the [Bluesky](https://blueskyweb.xyz) and [Fission](https://fission.codes) teams for pioneering this format.
+Thank you to [Chris Joel](https://github.com/cdata) of [Subconscious](https://subconscious.substack.com/), and the [Bluesky](https://blueskyweb.xyz) and [Fission](https://fission.codes) teams for pioneering this format.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The HTTP headers MUST include an `Authorization: Bearer` header, and MAY include
 | `Authorization: Bearer` | `ucan-jwt`       | Entry point "top-level" UCAN | Yes      |
 | `ucan`                  | `[cid:ucan-jwt]` | Mapping of CIDs to UCANs     | No       |
 
-FIXME should we not include the CID, and force the verfier to hash them?
-
 ## 2.1 Entry Point
 
 The entry-point for a UCAN chain MUST be `Authorization: Bearer <ucan>`. This is the only REQUIRED field. The UCAN contained in this field MUST be [encoded as a JWT](https://www.rfc-editor.org/rfc/rfc7519#section-3). Per the UCAN spec, this token SHOULD be unique per request.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The entry point UCAN MAY contain CID references to further UCANs as "proofs" (va
 
 ``` abnf
 ucan-header = "ucan:" 1*SP <ucan-assoc-list>
-ucan-assoc-list = <entry> *("," 1*SP <ucan-entry>) 
+ucan-assoc-list = <entry> *("," *SP <ucan-entry>) 
 ucan-entry = <cid> ":" <ucan-jwt>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UCAN as Bearer Token Specification v0.1.0
+# UCAN as Bearer Token Specification v0.2.0
 
 ## Editors
 
@@ -8,6 +8,7 @@
 
 * [Brooklyn Zelenka](https://github.com/expede), [Fission](https://fission.codes)
 * [Daniel Holmgren](https://github.com/dholms), [Bluesky](https://blueskyweb.xyz/)
+* [Hugo Dias](https://github.com/hugomrdias), DAG House
 
 # 0. Abstract
 


### PR DESCRIPTION
From a conversation on the [Discord](https://discord.gg/V9KH3npAqU), the browser `Header` API is easier to work with using lists rather than multiple headers with the same key. This is even called out right in the HTTP spec as a common pattern (though not for tabular data per se).

[📝 Preview](https://github.com/ucan-wg/ucan-as-bearer-token/blob/header-list/README.md)